### PR TITLE
timeline component should respond to tapeEvents directly

### DIFF
--- a/src/components/timeline/Timeline.ts
+++ b/src/components/timeline/Timeline.ts
@@ -79,6 +79,8 @@ export namespace Timeline {
           this.streamId
         ) {
           flag = true;
+        } else if(name === "tapeEvents"){
+          flag = true;
         }
       });
 


### PR DESCRIPTION
This is used within Profile component to present journey events as timeline.