### PR TITLE
Egiere/webpack build widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjaas/common-components",
-  "version": "2.0.1-dev.3",
+  "version": "2.1.0",
   "author": "Elena Giere",
   "license": "MIT",
   "repository": "https://github.com/CiscoDevNet/cjaas-common-components.git",
@@ -42,7 +42,7 @@
     "@momentum-ui/icons": "^7.54.0",
     "@momentum-ui/tokens": "^1.5.0",
     "@momentum-ui/utils": "^6.2.7",
-    "@momentum-ui/web-components": "2.1.8-dev.1",
+    "@momentum-ui/web-components": "^2.1.8",
     "lit-element": "2.3.1",
     "lit-html": "1.2.1"
   },
@@ -69,7 +69,7 @@
     "@momentum-ui/icons": "^7.54.0",
     "@momentum-ui/tokens": "^1.5.0",
     "@momentum-ui/utils": "^6.2.7",
-    "@momentum-ui/web-components": "2.1.8-dev.1",
+    "@momentum-ui/web-components": "^2.1.8",
     "@open-wc/testing-helpers": "1.8.9",
     "@percy/storybook": "^3.3.0",
     "@storybook/addon-a11y": "^5.3.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjaas/common-components",
-  "version": "2.0.0",
+  "version": "2.0.1-dev.2",
   "author": "Elena Giere",
   "license": "MIT",
   "repository": "https://github.com/CiscoDevNet/cjaas-common-components.git",
@@ -42,7 +42,7 @@
     "@momentum-ui/icons": "^7.54.0",
     "@momentum-ui/tokens": "^1.5.0",
     "@momentum-ui/utils": "^6.2.7",
-    "@momentum-ui/web-components": "^2.1.4",
+    "@momentum-ui/web-components": "2.1.8-dev.1",
     "lit-element": "2.3.1",
     "lit-html": "1.2.1"
   },
@@ -69,7 +69,7 @@
     "@momentum-ui/icons": "^7.54.0",
     "@momentum-ui/tokens": "^1.5.0",
     "@momentum-ui/utils": "^6.2.7",
-    "@momentum-ui/web-components": "^2.1.4",
+    "@momentum-ui/web-components": "2.1.8-dev.1",
     "@open-wc/testing-helpers": "1.8.9",
     "@percy/storybook": "^3.3.0",
     "@storybook/addon-a11y": "^5.3.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjaas/common-components",
-  "version": "2.0.1-dev.2",
+  "version": "2.0.1-dev.3",
   "author": "Elena Giere",
   "license": "MIT",
   "repository": "https://github.com/CiscoDevNet/cjaas-common-components.git",

--- a/src/[sandbox]/sandbox.ts
+++ b/src/[sandbox]/sandbox.ts
@@ -6,7 +6,7 @@ import { profileTemplate } from "./examples/profile";
 import { getWebexWalkinTemplate } from "./examples/webexWalkin";
 import { timerTemplate } from "./examples/timer";
 
-import "@momentum-ui/web-components";
+import "@momentum-ui/web-components/dist/comp/md-theme";
 
 @customElement("momentum-ui-web-components-sandbox")
 export class Sandbox extends LitElement {

--- a/src/components/profile/Profile.ts
+++ b/src/components/profile/Profile.ts
@@ -11,6 +11,11 @@ import { LitElement, html, property, PropertyValues } from "lit-element";
 import { ifDefined } from "lit-html/directives/if-defined";
 import styles from "./scss/module.scss";
 
+import "@momentum-ui/web-components/dist/comp/md-badge";
+import "@momentum-ui/web-components/dist/comp/md-icon";
+import "@momentum-ui/web-components/dist/comp/md-avatar";
+import "@momentum-ui/web-components/dist/comp/md-loading";
+
 export namespace ProfileView {
   interface ContactChannel {
     [key: string]: string;

--- a/src/components/timeline/Timeline.ts
+++ b/src/components/timeline/Timeline.ts
@@ -15,6 +15,10 @@ import { customElementWithCheck } from "@/mixins";
 import "../timeline/TimelineItem";
 import styles from "./scss/module.scss";
 
+import "@momentum-ui/web-components/dist/comp/md-badge";
+import "@momentum-ui/web-components/dist/comp/md-button";
+import "@momentum-ui/web-components/dist/comp/md-spinner";
+
 export namespace Timeline {
   export type TimelineItem = {
     title: string;

--- a/src/components/timer/Timer.ts
+++ b/src/components/timer/Timer.ts
@@ -4,6 +4,8 @@ import { nothing, html } from "lit-html";
 import { MILLISECONDS_PER_SECOND } from "@/constants";
 import styles from "./scss/module.scss";
 
+import "@momentum-ui/web-components/dist/comp/md-progress-bar";
+
 export namespace Timer {
   @customElementWithCheck("cjaas-timer")
   export class ELEMENT extends LitElement {

--- a/src/mixins/FocusTrapMixin.test.ts
+++ b/src/mixins/FocusTrapMixin.test.ts
@@ -319,7 +319,7 @@ describe("FocusTrap Mixin", () => {
   test("should prefer autofocus element in tab sequence", async () => {
     const focusTrap = el.shadowRoot!.querySelector<FocusTrap>("focus-trap");
     const focusableChild = focusTrap!.querySelector<FocusableChild>("focusable-child");
-    const mdInput = focusableChild!.shadowRoot!.querySelector("md-input");
+    const mdInput = focusableChild!.shadowRoot!.querySelector("md-input") as any;
 
     mdInput!.autofocus = true;
 
@@ -368,7 +368,7 @@ describe("FocusTrap Mixin", () => {
     await nextFrame();
     await elementUpdated(el);
 
-    const mdInput = focusableChild!.shadowRoot!.querySelector("md-input");
+    const mdInput = focusableChild!.shadowRoot!.querySelector("md-input") as any;
     const input = mdInput!.shadowRoot!.querySelector("input");
 
     input!.click();
@@ -381,7 +381,7 @@ describe("FocusTrap Mixin", () => {
   test("szhould change focus trap index if new focusable element was clicked", async () => {
     const focusTrap = el.shadowRoot!.querySelector<FocusTrap>("focus-trap");
     const focusableChild = focusTrap!.querySelector<FocusableChild>("focusable-child");
-    const mdInput = focusableChild!.shadowRoot!.querySelector("md-input");
+    const mdInput = focusableChild!.shadowRoot!.querySelector("md-input") as any;
     const input = mdInput!.shadowRoot!.querySelector("input");
 
     mdInput!.tabIndex = -1;

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -7,7 +7,6 @@ import * as path from "path";
 import RemovePlugin from "remove-files-webpack-plugin";
 import * as webpack from "webpack";
 import merge from "webpack-merge";
-import nodeExternals from "webpack-node-externals";
 import WebpackLoadChunksPlugin from "./webpack.plugin.LoadChunks";
 
 const pSrc = path.resolve("src");
@@ -162,7 +161,6 @@ const commonDist = merge(common, {
       minSize: 0
     }
   },
-  externals: [nodeExternals({ modulesFromFile: true, importType: "umd" })],
   plugins: [
     new CleanWebpackPlugin(),
     new WebpackLoadChunksPlugin({

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -7,6 +7,7 @@ import * as path from "path";
 import RemovePlugin from "remove-files-webpack-plugin";
 import * as webpack from "webpack";
 import merge from "webpack-merge";
+import nodeExternals from "webpack-node-externals";
 import WebpackLoadChunksPlugin from "./webpack.plugin.LoadChunks";
 
 const pSrc = path.resolve("src");
@@ -45,7 +46,8 @@ const common: webpack.Configuration = {
             name: "images-cjaas-common/[name].[hash:8].[ext]",
             esModule: false
           }
-        }
+        },
+        include: pSrc
       }
     ]
   }
@@ -70,9 +72,18 @@ function ruleCSS({ isDev }: { isDev: boolean }) {
     test: /\.scss$/,
     use: [
       { loader: "lit-scss-loader", options: { minify: !isDev } },
+      { loader: "string-replace-loader", options: { search: /\\/g, replace: "\\\\" } },
       { loader: "extract-loader" },
       { loader: "css-loader", options: { sourceMap: isDev, importLoaders: 2 } },
-      { loader: "sass-loader", options: { sourceMap: isDev } },
+      {
+        loader: "sass-loader",
+        options: {
+          sourceMap: isDev,
+          sassOptions: {
+            outputStyle: "compressed"
+          }
+        }
+      },
       {
         loader: "alias-resolve-loader",
         options: {
@@ -127,7 +138,6 @@ const dev = merge(commonDev, {
 // ----------
 
 const commonDist = merge(common, {
-  devtool: "source-map",
   entry: {
     "index-entry": "./src/index.ts",
     "comp/cjaas-profile-entry": "./src/components/profile/Profile.ts",
@@ -140,8 +150,9 @@ const commonDist = merge(common, {
     path: pDist,
     publicPath: "/",
     filename: "[name].js",
-    chunkFilename: "chunks/[id].js",
-    libraryTarget: "umd"
+    chunkFilename: "chunks/cjaas-[id].js",
+    libraryTarget: "umd",
+    jsonpFunction: "common-components-[id]"
   },
   optimization: {
     splitChunks: {
@@ -151,6 +162,7 @@ const commonDist = merge(common, {
       minSize: 0
     }
   },
+  externals: [nodeExternals({ modulesFromFile: true, importType: "umd" })],
   plugins: [
     new CleanWebpackPlugin(),
     new WebpackLoadChunksPlugin({


### PR DESCRIPTION
Webpack changes to remove the chance of jsonpFunction colliding with other webpack bundles. I also added a few things that I saw in the momentum webpack that were here regarding sass loading.

This along with changes to momentum webpack now work with angular and also allows cjaas widgets to work independently with it necessary dependencies.

I have each cjaas component importing the necessary individual momentum web components.