### PR TITLE
Identity Alias UI Update

### DIFF
--- a/src/[sandbox]/examples/identity.ts
+++ b/src/[sandbox]/examples/identity.ts
@@ -6,7 +6,7 @@ const alias = {
   namespace: "random",
   id: "123",
   aliases: ["Alex", "Bob"],
-  lastSeen: {} as JourneyEvent
+  lastSeen: {} as JourneyEvent,
 };
 
 const aliasDeleteInProgress = {

--- a/src/[sandbox]/examples/identity.ts
+++ b/src/[sandbox]/examples/identity.ts
@@ -1,13 +1,16 @@
 import "@/components/identity/Identity";
+import { JourneyEvent } from "@/components/identity/Identity";
 import { html } from "lit-element";
 
 const alias = {
+  namespace: "random",
+  id: "123",
   aliases: ["Alex", "Bob"],
-  lastSeen: null
+  lastSeen: {} as JourneyEvent
 };
 
 const aliasDeleteInProgress = {
-  Alex: true
+  Alex: true,
 };
 
 export const identityTemplate = html`

--- a/src/[sandbox]/sandbox.ts
+++ b/src/[sandbox]/sandbox.ts
@@ -102,10 +102,10 @@ export class Sandbox extends LitElement {
             <h2>cjaas-condition-block</h2>
             ${conditionBlockTemplate}
           </div> -->
-          <!-- <div class="container" aria-label="cjaas-identity">
+          <div class="container" aria-label="cjaas-identity">
             <h2>cjaas-Identity</h2>
             ${identityTemplate}
-          </div> -->
+          </div>
         </elix-list-explorer>
       </md-theme>
     `;

--- a/src/components/identity/Identity.ts
+++ b/src/components/identity/Identity.ts
@@ -5,6 +5,8 @@ import { html } from "lit-html";
 import "@momentum-ui/web-components/dist/comp/md-progress-bar";
 import styles from "./scss/identity.scss";
 
+const NO_ALIAS_TEXT = "Currently, no aliases exist.";
+
 export namespace Identity {
   @customElementWithCheck("cjaas-identity")
   export class ELEMENT extends LitElement {
@@ -63,19 +65,14 @@ export namespace Identity {
       `;
 
       const deleteIcon = (alias: string) => html`
-        <md-tooltip message="Delete Alias"
-          ><md-icon
-            color="red"
-            class="alias-delete"
-            name="icon-delete_14"
-            @click=${() => this.deleteAlias(alias)}
-          ></md-icon
+        <md-tooltip class="delete-icon-tooltip" message="Delete Alias">
+          <md-icon class="alias-delete-icon" name="icon-delete_14" @click=${() => this.deleteAlias(alias)}></md-icon
         ></md-tooltip>
       `;
 
       const aliases = (this.alias?.aliases?.slice().reverse() || []).map(alias => {
         return html`
-          <li>
+          <li class="alias-item">
             <span class="alias-text">${alias}</span>
             ${this.aliasDeleteInProgress[alias] ? spinnerInline : deleteIcon(alias)}
           </li>
@@ -101,7 +98,9 @@ export namespace Identity {
       const buttonText = this.isAPIInProgress ? spinnerInline : "Add";
 
       let consolidatedAliases = html`
-        <span class="alias-text">No Alias Found</span>
+        <div class="alt-consolidated-aliases-wrapper">
+          <span class="alias-text">${NO_ALIAS_TEXT}</span>
+        </div>
       `;
 
       if (this.getAPIInProgress) {
@@ -110,22 +109,24 @@ export namespace Identity {
         consolidatedAliases = aliasList;
       } else if (this.alias && !this.alias?.aliases) {
         consolidatedAliases = html`
-          <span class="alias-text">No Alias Found</span>
+          <div class="no-alias-wrapper">
+            <span class="alias-text">${NO_ALIAS_TEXT}</span>
+          </div>
         `;
       }
 
       return html`
         <div class="flex">
-          <md-input .placeholder=${inputPlaceholder} id="alias-input"></md-input>
-          <md-button .disabled=${this.isAPIInProgress} variant="green" @click=${async () => this.addAlias()}>
+          <md-input class="alias-input" placeholder=${inputPlaceholder} shape="pill" id="alias-input"></md-input>
+          <md-button .disabled=${this.isAPIInProgress} variant="secondary" @click=${async () => this.addAlias()}>
             ${buttonText}
           </md-button>
         </div>
         <div class="aliases">
-          <div>
-            <b>Aliases</b>
-            <md-tooltip .message=${tooltipMessage}>
-              <md-icon name="info_14"></md-icon>
+          <div class="header-container">
+            <h3 class="aliases-header">Aliases</h3>
+            <md-tooltip class="alias-info-tooltip" .message=${tooltipMessage}>
+              <md-icon class="alias-info-icon" name="info_14"></md-icon>
             </md-tooltip>
           </div>
           ${consolidatedAliases}

--- a/src/components/identity/scss/identity.scss
+++ b/src/components/identity/scss/identity.scss
@@ -8,8 +8,7 @@
 
 :host {
   display: block;
-  background-color: var(--md-secondary-bg-color);
-  border-radius: 4px;
+  font-family: "CiscoSansTT Regular", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 .flex {
@@ -23,45 +22,80 @@
     flex-shrink: 1;
   }
   md-button {
-    margin: 0 4px;
-    &::part(button) {
-      border-radius: 4px;
-      &:focus::after {
-        border-radius: 4px;
-      }
-    }
+    margin-left: 0.5rem;
+  }
+}
+
+.aliases {
+  padding: 0 0.5rem;
+}
+
+.header-container {
+  margin-bottom: 0.2rem;
+
+  .aliases-header {
+    color: var(--md-primary-text-color, #121212);
+    margin: 0;
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 16px;
+    display: inline-block;
+  }
+
+  .alias-info-icon {
+    margin-left: 0.1rem;
+    vertical-align: middle;
   }
 }
 
 .alias-text {
-  font-weight: 300;
-  font-size: 21px;
+  font-weight: 100;
+  font-size: 14px;
 }
 
 ul {
-  padding: 4px 12px;
+  padding: 0;
   margin: 0;
 
-  md-icon {
-    display: none;
+  .delete-icon-tooltip {
+    visibility: hidden;
   }
 
-  li {
+  .alias-delete-icon {
+    display: inline;
+    cursor: pointer;
+  }
+
+  .alias-item {
+    color: var(--md-secondary-text-color, #545454);
+    padding: 0.3rem 1rem;
+    font-size: 14px;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    md-spinner {
-      margin: 4px;
-    }
   }
 
   li:hover {
     background-color: var(--md-tertiary-bg-color);
 
-    md-icon {
-      display: inline;
-      cursor: pointer;
-      margin: 4px 4px 12px 4px;
+    .delete-icon-tooltip {
+      visibility: visible;
     }
   }
+}
+
+.alias-input::part(input) {
+  height: 2rem;
+  font-size: 14px;
+}
+
+.alt-consolidated-aliases-wrapper {
+  text-align: center;
+  margin: 1rem 0;
+}
+
+.spinner-container {
+  display: flex;
+  justify-content: center;
+  margin: 1rem 0;
 }


### PR DESCRIPTION
Updating the UI of the identity common-component after having a UX design review. 
This is what is looks like now:
<img width="659" alt="Screen Shot 2022-03-03 at 12 27 30 PM" src="https://user-images.githubusercontent.com/15151981/156658377-874dda45-c68f-4f22-b953-e45320a55d1c.png">

